### PR TITLE
Remove "mint green" from color (#1764)

### DIFF
--- a/lib/faker/default/app.rb
+++ b/lib/faker/default/app.rb
@@ -42,6 +42,8 @@ module Faker
         parse('app.author')
       end
 
+      # rubocop:disable Metrics/ParameterLists
+
       ##
       # Produces a String representing a semantic version identifier.
       #
@@ -60,7 +62,6 @@ module Faker
       #   Faker::App.semantic_version(patch: 5..6) #=> "7.2.6"
       #
       # @faker.version 1.4.3
-      # rubocop:disable Metrics/ParameterLists
       def semantic_version(legacy_major = NOT_GIVEN, legacy_minor = NOT_GIVEN, legacy_patch = NOT_GIVEN, major: 0..9, minor: 0..9, patch: 1..9)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|

--- a/lib/faker/default/avatar.rb
+++ b/lib/faker/default/avatar.rb
@@ -6,6 +6,8 @@ module Faker
       # @private
       SUPPORTED_FORMATS = %w[png jpg bmp].freeze
 
+      # rubocop:disable Metrics/ParameterLists
+
       ##
       # Produces a URL for an avatar from robohash.org
       #
@@ -36,7 +38,6 @@ module Faker
       #     #=> "https://robohash.org/my-own-slug.bmp?size=50x50&set=set1&bgset=bg1"
       #
       # @faker.version 1.4.3
-      # rubocop:disable Metrics/ParameterLists
       def image(legacy_slug = NOT_GIVEN, legacy_size = NOT_GIVEN, legacy_format = NOT_GIVEN, legacy_set = NOT_GIVEN, legacy_bgset = NOT_GIVEN, slug: nil, size: '300x300', format: 'png', set: 'set1', bgset: nil)
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|

--- a/lib/faker/default/chuck_norris.rb
+++ b/lib/faker/default/chuck_norris.rb
@@ -2,7 +2,7 @@
 
 module Faker
   class ChuckNorris < Base
-    flexible :name
+    flexible :chuck_norris
 
     class << self
       # from: https://github.com/jenkinsci/chucknorris-plugin/blob/master/src/main/java/hudson/plugins/chucknorris/FactGenerator.java

--- a/lib/faker/default/internet.rb
+++ b/lib/faker/default/internet.rb
@@ -73,6 +73,8 @@ module Faker
         end
       end
 
+      # rubocop:disable Metrics/ParameterLists
+
       ##
       # Produces a randomized string of characters suitable for passwords
       #
@@ -95,8 +97,8 @@ module Faker
       #   Faker::Internet.password(min_length: 10, max_length: 20, mix_case: true, special_characters: true) #=> "*%NkOnJsH4"
       #
       # @faker.version 2.1.3
-      # rubocop:disable Metrics/ParameterLists
       def password(legacy_min_length = NOT_GIVEN, legacy_max_length = NOT_GIVEN, legacy_mix_case = NOT_GIVEN, legacy_special_characters = NOT_GIVEN, min_length: 8, max_length: 16, mix_case: true, special_characters: false)
+        # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|
           keywords << :min_length if legacy_min_length != NOT_GIVEN
           keywords << :max_length if legacy_max_length != NOT_GIVEN
@@ -239,6 +241,7 @@ module Faker
         "#{ip_v6_address}/#{rand(1..127)}"
       end
 
+      # rubocop:disable Metrics/ParameterLists
       def url(legacy_host = NOT_GIVEN, legacy_path = NOT_GIVEN, legacy_scheme = NOT_GIVEN, host: domain_name, path: "/#{username}", scheme: 'http')
         # rubocop:enable Metrics/ParameterLists
         warn_for_deprecated_arguments do |keywords|

--- a/lib/faker/default/restaurant.rb
+++ b/lib/faker/default/restaurant.rb
@@ -4,8 +4,60 @@ module Faker
   class Restaurant < Base
     flexible :restaurant
 
-    def self.name
-      bothify(parse('restaurant.name'))
+    class << self
+      ##
+      # Produces the name of a restaurant.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Restaurant.name #=> "Curry King"
+      #
+      # @faker.version 1.9.2
+      def name
+        bothify(parse('restaurant.name'))
+      end
+
+      ##
+      # Produces a type of restaurant.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Restaurant.type #=> "Comfort Food"
+      #
+      # @faker.version 1.9.2
+      def type
+        fetch('restaurant.type')
+      end
+
+      ##
+      # Produces a description of a restaurant.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Restaurant.description
+      #     #=> "We are committed to using the finest ingredients in our recipes. No food leaves our kitchen that we ourselves would not eat."
+      #
+      # @faker.version 1.9.2
+      def description
+        fetch('restaurant.description')
+      end
+
+      ##
+      # Produces a review for a restaurant.
+      #
+      # @return [String]
+      #
+      # @example
+      #   Faker::Restaurant.review
+      #     #=> "Brand new. Great design. Odd to hear pop music in a Mexican establishment. Music is a bit loud. It should be background."
+      #
+      # @faker.version 1.9.2
+      def review
+        fetch('restaurant.review')
+      end
     end
   end
 end

--- a/lib/faker/games/zelda.rb
+++ b/lib/faker/games/zelda.rb
@@ -3,7 +3,7 @@
 module Faker
   class Games
     class Zelda < Base
-      flexible :space
+      flexible :zelda
       class << self
         ##
         # Produces the name of a Legend of Zelda game.

--- a/lib/locales/en/color.yml
+++ b/lib/locales/en/color.yml
@@ -1,4 +1,4 @@
 en:
   faker:
     color:
-      name: [red, green, blue, yellow, purple, mint green, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]
+      name: [red, green, blue, yellow, purple, teal, white, black, orange, pink, grey, maroon, violet, turquoise, tan, sky blue, salmon, plum, orchid, olive, magenta, lime, ivory, indigo, gold, fuchsia, cyan, azure, lavender, silver]


### PR DESCRIPTION
The list of colors are all single words except for "mint green".

As mint green is a pretty obscure color and doesn't fit with the format of every other color being a single word.

I purpose we remove this color for consistency.

Issue# 
------

Example:

https://github.com/faker-ruby/faker/issues/XXX

OR

`No-Story`

Description:
------
*Describe what this PR does in a few lines. If you are adding a new faker generator, please tell us how you're going to use this object. Use cases are important because we need to make sure that our faker generators are useful. After adding the description, please delete this line.*
